### PR TITLE
ci: ⬆️ Upgrade Maven cache, builder image, and verify lifecycle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,13 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
-          cache: maven
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
       - name: maven-test-native
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: maven-test-native
         run: |
-          ./mvnw -B -ntp verify -Pnative -Djacoco.haltOnFailure=false
+          ./mvnw -B -ntp verify -Djacoco.haltOnFailure=false
 
       - name: jacoco-report
         id: jacoco-report

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: maven-test-native
+      - name: maven-verify
         run: |
           ./mvnw -B -ntp verify -Djacoco.haltOnFailure=false
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: maven-test-native
         run: |
-          ./mvnw -B test -Pnative -Djacoco.haltOnFailure=false
+          ./mvnw -B -ntp verify -Pnative -Djacoco.haltOnFailure=false
 
       - name: jacoco-report
         id: jacoco-report

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,13 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
-          cache: maven
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
       - name: git-describe
         run: echo "DOCKER_TAG=$(git describe --tags --always --match "v[0-9]*.[0-9]*.[0-9]*" 2>/dev/null || echo 'v0.0.0')" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: maven-package-native-image
         run: |
-          ./mvnw -B package -Pnative \
+          ./mvnw -B verify \
           -Dspring-boot.build-image.imageName=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}
           -Dspring-boot.build-image.tags=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE }}:latest
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,26 +8,26 @@
 accepts all standard HTTP methods (GET, PUT, PATCH, POST, DELETE) and echoes the request body back to the caller. Its
 primary purpose is to serve as a reference scaffold demonstrating:
 
-- Spring Boot 4 + Java 21 REST API patterns
+- Spring Boot 4 + Java 25 REST API patterns
 - GraalVM native image compilation via Spring Boot Maven plugin
 - Spock/Groovy integration tests with MockMvc
 - JaCoCo code coverage enforcement (≥80% method coverage, 0 missed classes)
 - Automated CI/CD via GitHub Actions (build, test, CodeQL, Docker release, semver bumping)
 - GitHub Copilot customization via instructions, prompts, agents, and skills
 
-**Key technologies:** Java 21, Spring Boot 4, Spring MVC, Lombok, GraalVM Native Image, Spock 2.4, Groovy 5, JaCoCo,
+**Key technologies:** Java 25, Spring Boot 4, Spring MVC, Lombok, GraalVM Native Image, Spock 2.4, Groovy 5, JaCoCo,
 Maven Wrapper (`mvnw`)
 
-**Docker image:** `docker.io/ranma2913/echo-api`
+**Docker image:** `ghcr.io/ranma2913/echo-api`
 
 ---
 
 ## Setup Commands
 
-Prerequisites: Java 21 (Temurin recommended), Maven is provided via the wrapper (`./mvnw`).
+Prerequisites: Java 25 (Temurin recommended), Maven is provided via the wrapper (`./mvnw`).
 
 ```bash
-# Verify Java version (must be 21)
+# Verify Java version (must be 25)
 java -version
 
 # Install dependencies and compile (no tests)
@@ -71,8 +71,6 @@ Tests are written in **Groovy/Spock** and live under `src/test/groovy/`.
 # Run all tests (JVM mode) with JaCoCo coverage
 ./mvnw test
 
-# Run all tests in GraalVM native-test mode (used by CI)
-./mvnw -B test -Pnative -Djacoco.haltOnFailure=false
 
 # Run a single test class by name
 ./mvnw test -Dtest=EchoApiControllerSpec
@@ -97,7 +95,7 @@ open target/site/jacoco/index.html
 
 ## Code Style Guidelines
 
-- **Language:** Java 21 for production code; Groovy 5 for test code
+- **Language:** Java 25 for production code; Groovy 5 for test code
 - **Framework:** Spring Boot 4 / Spring MVC — use `@RestController`, `@RequestMapping`, `@ResponseStatus`
 - **Annotations:** Prefer Lombok (`@Slf4j`, `@SneakyThrows`) to reduce boilerplate
 - **Logging:** Use SLF4J via the Lombok `@Slf4j` annotation; never use `System.out`
@@ -125,30 +123,29 @@ The `native` Maven profile builds a GraalVM native image packaged as a Docker/OC
 
 ```bash
 # Build native OCI image locally (requires Docker daemon)
-./mvnw -B package -Pnative
-# Tagged as: ranma2913/echo-api:latest
+./mvnw -B package
+# Tagged as: ghcr.io/ranma2913/echo-api:local
 ```
 
 ```bash
 # Inspect the built image
-docker image inspect ranma2913/echo-api:latest
+docker image inspect ghcr.io/ranma2913/echo-api:local
 
 # Run the native image container
-docker run --rm -p 8080:8080 ranma2913/echo-api:latest
+docker run --rm -p 8080:8080 ghcr.io/ranma2913/echo-api:local
 ```
 
 ### CI/CD Pipelines (`.github/workflows/`)
 
-| Workflow           | Trigger                   | What it does                                                                                  |
-|--------------------|---------------------------|-----------------------------------------------------------------------------------------------|
-| `ci.yaml`          | push / PR / manual        | Builds native image, runs Spock tests, generates JaCoCo report, runs CodeQL security analysis |
-| `release.yaml`     | push to `master` / manual | Builds & pushes GraalVM native Docker image to Docker Hub (`ranma2913/echo-api`)              |
-| `semver-bump.yaml` | PR to non-master / manual | Bumps patch/minor/major version in `pom.xml`, commits, and tags                               |
+| Workflow           | Trigger                   | What it does                                                                                            |
+|--------------------|---------------------------|---------------------------------------------------------------------------------------------------------|
+| `ci.yaml`          | push / PR / manual        | Runs `mvnw verify`, executes Spock tests, generates JaCoCo report, runs CodeQL security analysis        |
+| `release.yaml`     | push to `master` / manual | Builds & pushes GraalVM native Docker image to GitHub Container Registry (`ghcr.io/ranma2913/echo-api`) |
+| `semver-bump.yaml` | PR to non-master / manual | Bumps patch/minor/major version in `pom.xml`, commits, and tags                                         |
 
 **Required GitHub secrets/variables for release:**
 
-- `DOCKER_USERNAME` (variable) — Docker Hub username
-- `DOCKER_PASSWORD` (secret) — Docker Hub password or access token
+- `GITHUB_TOKEN` (built-in) — automatically provided; used to push to `ghcr.io` and comment on PRs
 
 ---
 
@@ -176,7 +173,7 @@ docker run --rm -p 8080:8080 ranma2913/echo-api:latest
 
 **Application fails to start:**
 
-- Confirm `java -version` returns Java 21
+- Confirm `java -version` returns Java 25
 - Check `src/main/resources/config/application.properties` for misconfiguration
 
 **Tests fail with coverage violation:**
@@ -216,7 +213,7 @@ echo-api/
 │   ├── prompts/                      # GitHub Copilot prompt files
 │   ├── agents/                       # GitHub Copilot agent files
 │   └── skills/                       # GitHub Copilot skill files
-├── pom.xml                           # Maven build — Spring Boot 4, Java 21, Spock, JaCoCo, GraalVM
+├── pom.xml                           # Maven build — Spring Boot 4, Java 25, Spock, JaCoCo, GraalVM
 ├── mvnw / mvnw.cmd                   # Maven wrapper scripts
 ├── AGENTS.md                         # This file
 ├── llms.txt                          # LLM-friendly project index

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,7 @@ Local development reference for the `echo-api` project. For a project overview, 
 
 ## Prerequisites
 
-- **Java 21** (Temurin recommended) — `java -version` must report `21.x`
+- **Java 25** — `java -version` must report `25.x`
 - **Docker** (only required for native image builds)
 - Maven is provided via the `./mvnw` wrapper — no separate Maven installation needed
 
@@ -44,7 +44,7 @@ echo-api/
 │   ├── prompts/                      # GitHub Copilot prompt files
 │   ├── agents/                       # GitHub Copilot agent files
 │   └── skills/                       # GitHub Copilot skill files
-├── pom.xml                           # Maven build — Spring Boot 4, Java 21, Spock, JaCoCo, GraalVM
+├── pom.xml                           # Maven build — Spring Boot 4, Java 25, Spock, JaCoCo, GraalVM
 ├── mvnw / mvnw.cmd                   # Maven wrapper scripts
 ├── AGENTS.md                         # AI agent context and instructions
 ├── llms.txt                          # LLM-friendly project index
@@ -109,11 +109,9 @@ starting an actual HTTP server.
 ### Running Tests
 
 ```bash
-# Run all tests (JVM mode) — generates JaCoCo coverage report
+# Run all tests with JaCoCo coverage
 ./mvnw test
 
-# Run tests in GraalVM native-test mode (matches CI)
-./mvnw -B test -Pnative -Djacoco.haltOnFailure=false
 
 # Run a single spec by name
 ./mvnw test -Dtest=EchoApiControllerSpec
@@ -156,21 +154,21 @@ Test class names must end with `Spec` or `Test` to be picked up by Maven Surefir
 Requires Docker. Uses Spring Boot Buildpacks — no Dockerfile needed.
 
 ```bash
-# Build native OCI image (tagged ranma2913/echo-api:latest)
-./mvnw -B package -Pnative
+# Build native OCI image (tagged ghcr.io/ranma2913/echo-api:local)
+./mvnw -B package
 
 # Inspect the built image
-docker image inspect ranma2913/echo-api:latest
+docker image inspect ghcr.io/ranma2913/echo-api:local
 
 # Run the native image
-docker run --rm -p 8080:8080 ranma2913/echo-api:latest
+docker run --rm -p 8080:8080 ghcr.io/ranma2913/echo-api:local
 ```
 
 ---
 
 ## Coding Standards
 
-- **Production code:** Java 21 — use `@RestController`, `@RequestMapping`, `@ResponseStatus`
+- **Production code:** Java 25 — use `@RestController`, `@RequestMapping`, `@ResponseStatus`
 - **Test code:** Groovy 5 / Spock — specs named `*Spec.groovy`
 - **Boilerplate reduction:** Prefer Lombok annotations (`@Slf4j`, `@SneakyThrows`)
 - **Logging:** SLF4J via `@Slf4j` — never use `System.out.println`
@@ -189,7 +187,7 @@ For deeper AI-assisted development guidance, see [`AGENTS.md`](AGENTS.md) and [
 
 **Application fails to start**
 
-- Confirm `java -version` returns Java 21
+- Confirm `java -version` returns Java 25
 - Check `src/main/resources/config/application.properties` for misconfiguration
 
 **Tests fail with coverage violation**

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![CI](https://github.com/ranma2913/echo-api/actions/workflows/ci.yaml/badge.svg)](https://github.com/ranma2913/echo-api/actions/workflows/ci.yaml)
 [![Release](https://github.com/ranma2913/echo-api/actions/workflows/release.yaml/badge.svg)](https://github.com/ranma2913/echo-api/actions/workflows/release.yaml)
-[![Docker Image](https://img.shields.io/docker/v/ranma2913/echo-api?label=docker)](https://hub.docker.com/r/ranma2913/echo-api)
-[![Java](https://img.shields.io/badge/Java-21-blue)](https://adoptium.net/)
+[![Docker Image](https://img.shields.io/badge/ghcr.io-ranma2913%2Fecho--api-blue)](https://github.com/ranma2913/echo-api/pkgs/container/echo-api)
+[![Java](https://img.shields.io/badge/Java-25-blue)](https://adoptium.net/)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.3-brightgreen)](https://spring.io/projects/spring-boot)
 
 A minimal, production-ready Spring Boot REST API that echoes HTTP requests back to the caller. Send any HTTP method to
@@ -43,23 +43,23 @@ connection details — no configuration required.
 
 ## Technology Stack
 
-| Category           | Technology                                | Version        |
-|--------------------|-------------------------------------------|----------------|
-| Language           | Java                                      | 21 (LTS)       |
-| Framework          | Spring Boot                               | 4.0.3          |
-| Web Layer          | Spring MVC (`spring-boot-starter-webmvc`) | —              |
-| Build Tool         | Apache Maven (via `mvnw` wrapper)         | —              |
-| Test Language      | Groovy (Apache Groovy)                    | 5.0.4          |
-| Test Framework     | Spock Framework                           | 2.4-groovy-5.0 |
-| Test Runner        | Maven Surefire Plugin                     | —              |
-| Code Coverage      | JaCoCo                                    | 0.8.13         |
-| Boilerplate        | Lombok                                    | —              |
-| ASCII Art          | Banana (io.leego)                         | 2.1.0          |
-| Native Image       | GraalVM Native Maven Plugin               | —              |
-| Container Build    | Spring Boot Buildpacks                    | —              |
-| Container Registry | Docker Hub (`ranma2913/echo-api`)         | —              |
-| CI/CD              | GitHub Actions                            | —              |
-| Security Analysis  | GitHub CodeQL                             | —              |
+| Category           | Technology                                               | Version        |
+|--------------------|----------------------------------------------------------|----------------|
+| Language           | Java                                                     | 25             |
+| Framework          | Spring Boot                                              | 4.0.3          |
+| Web Layer          | Spring MVC (`spring-boot-starter-webmvc`)                | —              |
+| Build Tool         | Apache Maven (via `mvnw` wrapper)                        | —              |
+| Test Language      | Groovy (Apache Groovy)                                   | 5.0.4          |
+| Test Framework     | Spock Framework                                          | 2.4-groovy-5.0 |
+| Test Runner        | Maven Surefire Plugin                                    | —              |
+| Code Coverage      | JaCoCo                                                   | 0.8.14         |
+| Boilerplate        | Lombok                                                   | —              |
+| ASCII Art          | Banana (io.leego)                                        | 2.1.0          |
+| Native Image       | GraalVM Native Maven Plugin                              | —              |
+| Container Build    | Spring Boot Buildpacks                                   | —              |
+| Container Registry | GitHub Container Registry (`ghcr.io/ranma2913/echo-api`) | —              |
+| CI/CD              | GitHub Actions                                           | —              |
+| Security Analysis  | GitHub CodeQL                                            | —              |
 
 ---
 
@@ -92,7 +92,7 @@ There is no database, no external dependencies, and no required environment vari
 
 ```bash
 # Pull and run the latest pre-built native image
-docker run --rm -p 8080:8080 ranma2913/echo-api:latest
+docker run --rm -p 8080:8080 ghcr.io/ranma2913/echo-api:latest
 ```
 
 The API is available at `http://localhost:8080`.
@@ -168,18 +168,17 @@ curl -s -X POST http://localhost:8080/echo \
 
 ## CI/CD Pipelines
 
-| Workflow           | Trigger                                | What it does                                                                                  |
-|--------------------|----------------------------------------|-----------------------------------------------------------------------------------------------|
-| `ci.yaml`          | push / PR / `workflow_dispatch`        | Builds native image, runs Spock tests, posts JaCoCo PR comment, runs CodeQL security analysis |
-| `release.yaml`     | push to `master` / `workflow_dispatch` | Builds & pushes GraalVM native Docker image to Docker Hub (`ranma2913/echo-api`)              |
-| `semver-bump.yaml` | PR to non-master / `workflow_dispatch` | Bumps patch/minor/major version in `pom.xml`, commits, and tags                               |
+| Workflow           | Trigger                                | What it does                                                                                            |
+|--------------------|----------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `ci.yaml`          | push / PR / `workflow_dispatch`        | Runs `mvnw verify`, executes Spock tests, posts JaCoCo PR comment, runs CodeQL security analysis        |
+| `release.yaml`     | push to `master` / `workflow_dispatch` | Builds & pushes GraalVM native Docker image to GitHub Container Registry (`ghcr.io/ranma2913/echo-api`) |
+| `semver-bump.yaml` | PR to non-master / `workflow_dispatch` | Bumps patch/minor/major version in `pom.xml`, commits, and tags                                         |
 
 ### Required GitHub Secrets / Variables
 
-| Name              | Type     | Description                         |
-|-------------------|----------|-------------------------------------|
-| `DOCKER_USERNAME` | Variable | Docker Hub username                 |
-| `DOCKER_PASSWORD` | Secret   | Docker Hub password or access token |
+| Name           | Type     | Description                                                          |
+|----------------|----------|----------------------------------------------------------------------|
+| `GITHUB_TOKEN` | Built-in | Automatically provided; used to push to `ghcr.io` and comment on PRs |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # echo-api
 
-> A Spring Boot REST API that echoes request bodies back to the caller. All HTTP methods (GET, PUT, PATCH, POST, DELETE) are supported on the `/echo` endpoint. Built with Java 21, Spring Boot 4, GraalVM native image support, and tested with Spock/Groovy.
+> A Spring Boot REST API that echoes request bodies back to the caller. All HTTP methods (GET, PUT, PATCH, POST, DELETE) are supported on the `/echo` endpoint. Built with Java 25, Spring Boot 4, GraalVM native image support, and tested with Spock/Groovy.
 
 This project demonstrates a minimal, production-ready Spring Boot REST API scaffold with native image support, automated CI/CD via GitHub Actions, JaCoCo code coverage enforcement, and GitHub Copilot customization via instructions, prompts, agents, and skills.
 
@@ -12,7 +12,7 @@ This project demonstrates a minimal, production-ready Spring Boot REST API scaff
 
 ## Configuration
 
-- [pom.xml](pom.xml): Maven build configuration — Spring Boot 4, Java 21, Spock 2.4, Groovy 5, JaCoCo, GraalVM native image
+- [pom.xml](pom.xml): Maven build configuration — Spring Boot 4, Java 25, Spock 2.4, Groovy 5, JaCoCo, GraalVM native image
 - [application.properties](src/main/resources/config/application.properties): Application and logging configuration
 
 ## Source Code
@@ -28,7 +28,7 @@ This project demonstrates a minimal, production-ready Spring Boot REST API scaff
 ## CI/CD Workflows
 
 - [ci.yaml](.github/workflows/ci.yaml): Continuous integration — builds native image, runs tests, JaCoCo coverage report, CodeQL security analysis
-- [release.yaml](.github/workflows/release.yaml): Release pipeline — builds and pushes GraalVM native Docker image to Docker Hub on master branch
+- [release.yaml](.github/workflows/release.yaml): Release pipeline — builds and pushes GraalVM native Docker image to GitHub Container Registry (`ghcr.io`) on master branch
 - [semver-bump.yaml](.github/workflows/semver-bump.yaml): Semantic versioning automation — bumps patch/minor/major version on pull requests
 
 ## GitHub Copilot Customization

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,10 @@
     <maven-surefire-plugin.jvm-flags>-Xmx2048m</maven-surefire-plugin.jvm-flags>
 
     <!-- Native Image Configs -->
+    <docker.registry>ghcr.io</docker.registry>
     <docker.org>ranma2913</docker.org>
     <docker.repo>${project.artifactId}</docker.repo>
-    <spring-boot.build-image.imageName>${docker.org}/${docker.repo}:latest</spring-boot.build-image.imageName>
+    <spring-boot.build-image.imageName>${docker.registry}/${docker.org}/${docker.repo}:local</spring-boot.build-image.imageName>
     <spring-boot.build-image.createdDate>now</spring-boot.build-image.createdDate>
     <spring-boot.build-image.builder>paketobuildpacks/builder-noble-java-tiny</spring-boot.build-image.builder><!-- https://github.com/paketo-buildpacks/builder-noble-java-tiny -->
     <spring-boot.build-image.imagePlatform>linux/amd64</spring-boot.build-image.imagePlatform>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
           </execution>
           <execution>
             <id>jacoco-check</id>
-            <phase>test</phase><!-- https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#Lifecycle_Reference -->
+            <phase>verify</phase><!-- https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#Lifecycle_Reference -->
             <goals>
               <goal>check</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,9 @@
     <docker.repo>${project.artifactId}</docker.repo>
     <spring-boot.build-image.imageName>${docker.org}/${docker.repo}:latest</spring-boot.build-image.imageName>
     <spring-boot.build-image.createdDate>now</spring-boot.build-image.createdDate>
-    <spring-boot.build-image.runImage>paketobuildpacks/run-jammy-tiny</spring-boot.build-image.runImage>
+    <spring-boot.build-image.builder>paketobuildpacks/builder-noble-java-tiny</spring-boot.build-image.builder><!-- https://github.com/paketo-buildpacks/builder-noble-java-tiny -->
     <spring-boot.build-image.imagePlatform>linux/amd64</spring-boot.build-image.imagePlatform>
+    <spring-boot.build-image.tags/>
   </properties>
 
   <dependencies>
@@ -86,6 +87,19 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-help-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>print-active-profiles</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>active-profiles</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -150,6 +164,11 @@
             <goals>
               <goal>build-image-no-fork</goal>
             </goals>
+            <configuration>
+              <image>
+                <tags>${spring-boot.build-image.tags}</tags>
+              </image>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -240,4 +259,39 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>core</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-maven-plugin</artifactId>
+            <configuration>
+              <image>
+                <env>
+                  <BP_DEPENDENCY_MIRROR_REPO1_MAVEN_ORG>https://maven-central.storage-download.googleapis.com</BP_DEPENDENCY_MIRROR_REPO1_MAVEN_ORG>
+                  <credentials_JFROG_SAAS_USERNAME>${env.credentials_JFROG_SAAS_USERNAME}</credentials_JFROG_SAAS_USERNAME>
+                  <credentials_JFROG_SAAS_TOKEN>${env.credentials_JFROG_SAAS_TOKEN}</credentials_JFROG_SAAS_TOKEN>
+                </env>
+                <bindings>
+                  <!-- 1) Mount your existing settings.xml into the binding -->
+                  <binding>${user.home}/.m2/settings.xml:/platform/bindings/maven/settings.xml:ro</binding>
+                  <!-- 2) Mount a tiny file that contains the word: maven -->
+                  <binding>${user.home}/.m2/cnb-binding-type-maven:/platform/bindings/maven/type:ro</binding>
+                  <!-- 3) Speed up builds by mounting your local Maven repository into the binding -->
+                  <binding>${user.home}/.m2/repository:/home/vcap/.m2/repository:rw</binding>
+                </bindings>
+              </image>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Overhauls the CI/CD workflows and Maven build configuration to use
explicit Maven caching, the new Paketo noble-java-tiny builder, and
the `verify` lifecycle phase consistently.

**ci.yaml**
- Replace `actions/setup-java` built-in `cache: maven` with an
  explicit `actions/cache@v4` step keyed on `pom.xml` hash for
  more granular cache control
- Rename `maven-test-native` step to `maven-verify` and switch
  command from `./mvnw -B test -Pnative` to `./mvnw -B -ntp verify`
  — runs the full verify lifecycle (compile → test → package →
  verify) without the native profile, matching the release pipeline

**release.yaml**
- Same `actions/cache@v4` explicit caching as ci.yaml
- Switch `maven-package-native-image` command from
  `-Pnative package` to `verify` for lifecycle consistency

**pom.xml**
- Add `docker.registry=ghcr.io` property; update default
  `imageName` to `ghcr.io/ranma2913/echo-api:local`
- Replace `runImage` (paketobuildpacks/run-jammy-tiny) with
  `builder` (paketobuildpacks/builder-noble-java-tiny) for
  Ubuntu Noble base and Java-optimised tiny runtime
- Add `maven-help-plugin` execution to print active profiles
  on `initialize` phase for build transparency
- Move JaCoCo `check` goal from `test` phase to `verify` phase
  to align with standard Maven lifecycle
- Add `spring-boot-maven-plugin` `<tags>` configuration to
  support dynamic tag injection from CI
- Add `core` Maven profile (Mac-activated) that mounts local
  `~/.m2` settings, repository, and JFrog credentials into the
  Buildpacks image build environment

**Docs (AGENTS.md, DEVELOPMENT.md, README.md, llms.txt)**
- Update all Java 21 → 25 references
- Update Docker Hub → ghcr.io image references and badges
- Remove outdated `-Pnative` test command examples
- Update CI/CD pipeline and secrets table to reflect `GITHUB_TOKEN`
  replacing `DOCKER_USERNAME`/`DOCKER_PASSWORD`

Aligns the full build pipeline on the `verify` lifecycle so local
builds, CI test runs, and release builds all exercise the same Maven
phases. Explicit cache keys prevent stale cache hits across
`pom.xml` changes.