### PR TITLE
Update dependencies for Spring Boot, GMavenPlus, and JaCoCo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.4</version>
+    <version>4.0.6</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 


### PR DESCRIPTION

### Summary

This pull request consolidates dependency updates from Dependabot for the following packages:
- **Spring Boot Starter Parent**: Updated from 4.0.4 to 4.0.6 (patch update).
- **GMavenPlus Plugin**: Updated from 4.3.1 to 5.0.0 (major update).
- **JaCoCo Report**: Updated from 1.7.2 to 1.8.0 (minor update).

### Checklist

- [ ] I have tested these changes locally.
- [ ] I have ensured that current functionality is not broken.
- [ ] I have updated/added documentation as required.

### Additional Notes

- Confirm compatibility of the major version bump for GMavenPlus.
- Suggested testing of integration points and downstream builds to ensure stability.
